### PR TITLE
Add CI and repo protection scaffolding

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Release-sensitive files and repository controls require engineering review.
+/.github/ @creditkey/engineers
+/package.json @creditkey/engineers
+/package-lock.json @creditkey/engineers
+/rollup.config.js @creditkey/engineers
+/build.sh @creditkey/engineers
+/Dockerfile @creditkey/engineers
+/.node-version @creditkey/engineers
+/.nvmrc @creditkey/engineers
+/.tool-versions @creditkey/engineers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Run tests
+        run: npm test

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities through GitHub's Security Advisory feature:
+[https://github.com/creditkey/creditkey-js/security/advisories/new](https://github.com/creditkey/creditkey-js/security/advisories/new)
+
+Do not open public issues for security vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5295,6 +5295,23 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",


### PR DESCRIPTION
## Summary
- add a minimal GitHub Actions CI workflow for install, build, and test
- add CODEOWNERS coverage for release-sensitive repo controls
- add a SECURITY.md policy for private vulnerability reporting
- refresh package-lock.json so npm ci is reproducible on the current dependency graph

## Verification
- npm ci
- npm run build
- npm test